### PR TITLE
Sync fix

### DIFF
--- a/assets/configset/baseconfig
+++ b/assets/configset/baseconfig
@@ -18,6 +18,13 @@ config system interface
         set type physical
         set allowaccess ping https ssh fgfm
     next
+        edit "port3"
+        set vdom "root"
+        set defaultgw enable
+        set mode dhcp
+        set type physical
+        set allowaccess ping https ssh fgfm
+    next
     edit "loopback"
         set vdom "root"
         set ip 192.168.199.1 255.255.255.255

--- a/index.ts
+++ b/index.ts
@@ -475,7 +475,7 @@ export class GCP extends CloudPlatform<
                 }
             });
             let running = true;
-            let attachEIPTimeLimit = 45;
+            let attachEIPTimeLimit = 45; // Default 45 seconds max.
             console.log(addAddressReq.data);
             let startTime = Date.now();
             while (running === true && startTime + attachEIPTimeLimit > Date.now()) {
@@ -1081,7 +1081,7 @@ exports.main = async function (req, res, callback) {
         const RuntimeAgent: GCPRuntimeAgent = new GCPRuntimeAgent(req, context, logger, callback);
         const platform: GCP = new GCP(RuntimeAgent);
         const handler = new GCPAutoScaleHandler(platform);
-        // HOTFIX for sync issue. Now always return PrimaryIp. Might be a good idea to always do this.
+        // HOTFIX for sync issue( 0711303). Now always return PrimaryIp. Might be a good idea to always do this.
         const getPrimaryRecord = await platform.getMasterRecord();
         console.log('Calling Handler');
         callback = (err, data) => {

--- a/vars.tf
+++ b/vars.tf
@@ -26,7 +26,7 @@ data "google_compute_zones" "get_zones" {
 # FortiGate Image
 variable "fortigate_image" {
   type = "string"
-  default = "projects/fortigcp-project-001/global/images/fortinet-fgt-644-20201217-001-w-license"    #Default 6.2.3 PAYG
+  default = "projects/fortigcp-project-001/global/images/fortinet-fgtondemand-700-20210407-001-w-license"    #Default 6.4.5 PAYG
 }
 #Default
 variable "instance" {
@@ -79,6 +79,10 @@ variable "protected_subnet" {
 variable "public_managment_subnet" {
   type    = "string"
   default = "172.16.16.0/24"
+}
+variable "sync_subnet" {
+  type    = "string"
+  default = "172.16.24.0/24"
 }
 variable "firewall_allowed_range" {
   type = "string"

--- a/vars.tf
+++ b/vars.tf
@@ -26,7 +26,7 @@ data "google_compute_zones" "get_zones" {
 # FortiGate Image
 variable "fortigate_image" {
   type = "string"
-  default = "projects/fortigcp-project-001/global/images/fortinet-fgtondemand-623-20191223-001-w-license"    #Default 6.2.3 PAYG
+  default = "projects/fortigcp-project-001/global/images/fortinet-fgt-644-20201217-001-w-license"    #Default 6.2.3 PAYG
 }
 #Default
 variable "instance" {


### PR DESCRIPTION
This is a hotfix for the current sync issues we see.

This will need some additional testing for previous builds, but initial tests with the new dev-build work well. 

The following changes have been made:

- I have increased the number of ports/vpc to three 
- The third port is now the sync interface for autoscale, and the autoscale code has been adjusted to point to the third interface for "master-ip"
- The code will always send back the response {'master-ip:<master Ip from firestore database>'} if no other response (bootstrap etc) is found.
- I have also added a check for the IP switch before sending back the initial response, but this seems to make no difference.

Review and let me know


